### PR TITLE
removed scpi inheritance from instrument. removed virtual awg and scope inheritance from scpi

### DIFF
--- a/src/piec/drivers/awg/virtual_awg.py
+++ b/src/piec/drivers/awg/virtual_awg.py
@@ -9,9 +9,9 @@ import numpy as np
 
 from ..virtual_instrument import VirtualInstrument
 from .awg import Awg
-from ..scpi import Scpi
 
-class VirtualAwg(VirtualInstrument, Awg, Scpi):
+
+class VirtualAwg(VirtualInstrument, Awg):
     """
     Virtual version of the Keysight81150a AWG for simulation/testing.
     Stores state internally and generates synthetic output.

--- a/src/piec/drivers/oscilloscope/virtual_oscilloscope.py
+++ b/src/piec/drivers/oscilloscope/virtual_oscilloscope.py
@@ -6,10 +6,9 @@ import numpy as np
 import pandas as pd
 
 from .oscilloscope import Oscilloscope
-from ..scpi import Scpi
 from ..virtual_instrument import VirtualInstrument
 
-class VirtualScope(VirtualInstrument, Oscilloscope, Scpi):
+class VirtualScope(VirtualInstrument, Oscilloscope):
     """
     Virtual version of the KeysightDSOX3024a oscilloscope for simulation/testing.
     Stores state internally and generates synthetic data.

--- a/src/piec/drivers/scpi.py
+++ b/src/piec/drivers/scpi.py
@@ -1,9 +1,9 @@
 """
 This is the top level instrument that dictates if something is scpi, dac, arduino, etc.
 """
-from .instrument import Instrument # Assuming instrument.py is in the same directory
 
-class Scpi(Instrument):
+
+class Scpi():
     # Initializer / Instance attributes
     """
     All SCPI instruments must allow for all base SCPI commands to work!


### PR DESCRIPTION
Removed scpi inheriting from instruments. Also removed virtual awg and scope inheriting from scpi. Tested with virtual hysteresis and it worked. 